### PR TITLE
Update Layer.Raphael.js

### DIFF
--- a/src/layer/vector/Layer.Raphael.js
+++ b/src/layer/vector/Layer.Raphael.js
@@ -50,7 +50,11 @@ R.Layer = L.Class.extend({
 L.Map.include({
 	_initRaphaelRoot: function () {
 		if (!this._raphaelRoot) {
-			this._raphaelRoot = this._panes.overlayPane;
+			overlayPane = this._panes.overlayPane;
+			var raphaelDiv = document.createElement("div");
+            		raphaelDiv.setAttribute("style","z-index:-1;");
+            		overlayPane.appendChild(raphaelDiv);
+			this._raphaelRoot = raphaelDiv;
 			this._paper = Raphael(this._raphaelRoot);
 
 			this.on('moveend', this._updateRaphaelViewport);


### PR DESCRIPTION
Added a new div under overlayPane for raphaelRoot.  This allows raphael objects to "play nicely" with other non-Raphael SVG and VML objects that are also plotted on the map at the same time.  

Without this extra div, non-Raphael objects have some erratic behavior:  they sometimes disappear and/or are offset incorrectly, especially after panning and zooming.
